### PR TITLE
Make pagination links look clickable

### DIFF
--- a/tipuesearch/tipuesearch.css
+++ b/tipuesearch/tipuesearch.css
@@ -122,6 +122,7 @@ http://www.tipue.com/search
      border: 1px solid #e2e2e2;
      border-radius: 1px;
 	color: #333;
+	cursor: pointer;
 	margin-right: 7px;
 	text-decoration: none;
 	text-align: center;


### PR DESCRIPTION
The pagination link elements lack a `href` property so they do not look like links in all browsers. Styling the cursor in CSS fixes this.