### PR TITLE
Add hash and reset options

### DIFF
--- a/tipuesearch/tipuesearch.js
+++ b/tipuesearch/tipuesearch.js
@@ -31,7 +31,9 @@ http://www.tipue.com/search
           'showTime'               : true,
           'showTitleCount'         : true,
           'showURL'                : true,
-          'wholeWords'             : true
+          'wholeWords'             : true,
+          'useHash':               false,
+          'resetOnClear':          false
           
           }, options);
           
@@ -142,6 +144,12 @@ http://www.tipue.com/search
                     var d_o = $('#tipue_search_input').val();
                     var d = d_o.toLowerCase();
                     d = $.trim(d);
+
+                    if (d === '' && set.resetOnClear)
+                    {
+                      $('#tipue_search_content').hide();
+                      return;
+                    }
                     
                     if ((d.match("^\"") && d.match("\"$")) || (d.match("^'") && d.match("'$")))
                     {
@@ -372,7 +380,12 @@ http://www.tipue.com/search
                               for (var i = 0; i < found.length; i++)
                               {
                                    if (l_o >= start && l_o < set.show + start)
-                                   {                                   
+                                   {
+                                        if (set.useHash)
+                                        {
+                                          found[i].url = found[i].url + '#' + d;
+                                        }
+
                                         out += '<div class="tipue_search_content_title"><a href="' + found[i].url + '"' + tipue_search_w + '>' +  found[i].title + '</a></div>';
  
                                         if (set.debug)


### PR DESCRIPTION
1. Add `useHash` option which appends the search subject to the result URLs, e.g.: 

Search: `fluffy`

Results:

`http://mypetrescue.com/puppies#fluffy`
`http://mypetrescue.com/kittens#fluffy`

It allows to place the anchors on the founded page and to navigate directly to the first occurrence of the subject on the page as well as to highlight all the occurrences.

Example of placing the anchors using [jQuery Highlight plugin](https://github.com/knownasilya/jquery-highlight):

```
$(function() {
  if (location.hash) {
    let hash = location.hash.substring(1).trim();
    if (hash) {
      $('#searchable_content').highlight(hash, { element: 'a' });
      $('#searchable_content').find('a.highlight').attr('name', hash);
    }
  }
});
```

2. Add `resetOnClear` option which hides the previous results when the search field is cleared.
